### PR TITLE
GitHub action for publishing themes gallery

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -42,10 +42,10 @@ jobs:
           git config --local user.name "GitHub Action"
           git add docs/content/themes
           git commit -m "Update themes gallery" -a
-      - name: Push changes
-        uses: ad-m/github-push-action@master
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v2
         with:
-          repository: 'getzola/zola'
-          branch: 'master'
-          directory: 'zola'
-          github_token: ${{ secrets.TOKEN }}
+          title: 'Update themes gallery'
+          path: 'zola'
+          token: ${{ secrets.TOKEN }}
+          branch-suffix: 'timestamp'

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,0 +1,51 @@
+on: 
+  push:
+    branches:
+      - master
+
+name: Generate themes site
+
+jobs:
+  generate:
+    name: Generate the static themes site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout latest
+        uses: actions/checkout@master
+        with:
+          submodules: "recursive"
+      - name: Setup Python 3
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+      - name: Install Python requirements
+        run: pip install -r requirements.txt
+      - name: Run the generator script
+        run: python generate_docs.py site
+      - uses: actions/upload-artifact@v2
+        with:
+          name: themes-directory
+          path: site/*
+      - name: Checkout zola repo
+        uses: actions/checkout@v2
+        with:
+          repository: 'getzola/zola'
+          path: 'zola'
+          token: ${{ secrets.TOKEN }}
+      - name: Copy updated themes site
+        run: |
+          cp -r site/* zola/docs/content/themes/
+      - name: Commit files
+        run: |
+          cd zola
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add docs/content/themes
+          git commit -m "Update themes gallery" -a
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          repository: 'getzola/zola'
+          branch: 'master'
+          directory: 'zola'
+          github_token: ${{ secrets.TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -65,3 +65,6 @@
 [submodule "simple-dev-blog"]
 	path = simple-dev-blog
 	url = https://github.com/bennetthardwick/simple-dev-blog-zola-starter
+[submodule "anpu"]
+	path = anpu
+	url = https://github.com/zbrox/anpu-zola-theme.git

--- a/generate_docs.py
+++ b/generate_docs.py
@@ -110,7 +110,14 @@ homepage = "{author_homepage}"
         page_dir = os.path.join(container, self.name)
         os.makedirs(page_dir)
 
+        required_metadata = ['name']
+
         with open(os.path.join(page_dir, "index.md"), "w") as f:
+            metadata_check = [required for required in required_metadata if required not in self.metadata]
+            if len(metadata_check) > 0:
+                print("Theme {} is missing required metadata: {}; skipping...".format(self.name, ", ".join(metadata_check)))
+                return
+            print("Writing theme info as zola content: {}".format(self.name))
             f.write(self.to_zola_content())
 
         shutil.copyfile(

--- a/generate_docs.py
+++ b/generate_docs.py
@@ -138,6 +138,10 @@ def read_themes():
         if item.startswith(".") or not os.path.isdir(full_path) or item == "themes":
             continue
 
+        if not os.path.exists(os.path.join(full_path, "README.md")):
+            print(" !! Theme {} is missing README.md, skipping !!".format(item))
+            continue
+
         if not os.path.exists(os.path.join(full_path, "screenshot.png")):
             print(" !! Theme {} is missing screenshot.png, skipping !!".format(item))
             continue

--- a/generate_docs.py
+++ b/generate_docs.py
@@ -123,7 +123,7 @@ def read_themes():
     base = "./"
     themes = []
 
-    for item in os.listdir(base):
+    for item in sorted(os.listdir(base)):
         full_path = os.path.join(base, item)
         if item == "env" or item == "venv":
             continue


### PR DESCRIPTION
I tested this with another repo and seems to work.

Here's a breakdown of its actions:
- initialzes this repo and submodules
- runs generator script to produce themes gallery in a folder called `site`
- saves an artifact of the generated gallery in the running github action
- clones `getzola/zola` in a folder called `zola`
- copies the contents of `site` in `zola/docs/content/themes`
- cd's in the `zola` folder, sets the commit author name and email and creates a commit with the message "Update themes gallery"
- pushes to `getzola/zola`

For this to work a secret needs to be added in the settings of the themes repository with the name TOKEN. Here's [the documentation](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line) on creating personal access tokens.

Btw I'm sorry but I have no idea why the older commits are showing in this pull request, since the fork seems to be in sync.