### PR TITLE
Fix metadata check in generate script

### DIFF
--- a/generate_docs.py
+++ b/generate_docs.py
@@ -110,13 +110,7 @@ homepage = "{author_homepage}"
         page_dir = os.path.join(container, self.name)
         os.makedirs(page_dir)
 
-        required_metadata = ['name']
-
         with open(os.path.join(page_dir, "index.md"), "w") as f:
-            metadata_check = [required for required in required_metadata if required not in self.metadata]
-            if len(metadata_check) > 0:
-                print("Theme {} is missing required metadata: {}; skipping...".format(self.name, ", ".join(metadata_check)))
-                return
             print("Writing theme info as zola content: {}".format(self.name))
             f.write(self.to_zola_content())
 
@@ -146,7 +140,15 @@ def read_themes():
             print(" !! Theme {} is missing screenshot.png, skipping !!".format(item))
             continue
 
-        themes.append(Theme(item, full_path))
+        theme = Theme(item, full_path)
+
+        required_metadata = ['name']
+        metadata_check = [required for required in required_metadata if required not in theme.metadata]
+        if len(metadata_check) > 0:
+            print("Theme {} is missing required metadata: {}; skipping...".format(theme.name, ", ".join(metadata_check)))
+            continue
+
+        themes.append(theme)
 
     return themes
 


### PR DESCRIPTION
I've moved the metadata check where other checks are made and just skip adding the theme object to the list of theme objects if some required metadata property is missing (currently only one required is "name").

Previously the check was done way later in the function `to_zola_folder` and a directory with an empty `index.md` was already created for the invalid theme, which would break the site building.

This should fix the current issue with the build automation of the themes site that I saw in the netlify checks for the already created pull requests.