### PR TITLE
Add abridge theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -161,3 +161,6 @@
 [submodule "zhuia"]
 	path = zhuia
 	url = https://github.com/gicrisf/zhuia
+[submodule "themes/abridge"]
+	path = themes/abridge
+	url = https://github.com/Jieiku/abridge.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -155,6 +155,9 @@
 [submodule "kodama-theme"]
 	path = kodama-theme
 	url = https://github.com/adfaure/kodama-theme
+[submodule "kodama-theme"]
+        path = abridge
+        url = https://github.com/Jieiku/abridge
 [submodule "zhuia"]
 	path = zhuia
 	url = https://github.com/gicrisf/zhuia


### PR DESCRIPTION
I have been building this theme in my spare time over the last couple weeks.

It is responsive lightweight blog theme, using semantic html and no javascript. (the search may end up being the only thing that requires javascript.)

There is a bundled css framework that is based on a css framework I also worked on over the last couple weeks. (abridge.css)[https://github.com/Jieiku/abridge.css]

I spent most of the time reading the documentation and learning from what other themes have done.