### PR TITLE
Add andromeda theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -213,3 +213,6 @@
 [submodule "bearblog"]
 	path = bearblog
 	url = https://codeberg.org/alanpearce/zola-bearblog
+[submodule "andromeda"]
+	path = andromeda
+	url = git@github.com:Pixadus/andromeda-theme.git


### PR DESCRIPTION
Created the Andromeda photojournal/blog theme with a demo available at [https://andromeda-theme.netlify.app/](https://andromeda-theme.netlify.app/) and repo at [https://github.com/Pixadus/andromeda-theme](https://github.com/Pixadus/andromeda-theme), looking to add it to the official Zola themes repo. 