### PR TITLE
feat(ci): add scheduled job to update all themes

### DIFF
--- a/.github/workflows/update-all-themes.yml
+++ b/.github/workflows/update-all-themes.yml
@@ -1,0 +1,25 @@
+name: Update all themes
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "51 5 * * 1"
+
+jobs:
+  update-all-themes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - name: Update submodules
+        run: "git submodule update --remote"
+      - name: Commit and push changes
+        run: |
+          git status
+          if [[ `git status --short` ]]; then
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+            git commit -am "Update all themes"
+            git push
+          fi


### PR DESCRIPTION
I recently merged a PR to the [zola-bearblog](https://codeberg.org/alanpearce/zola-bearblog) theme, and noticed that the readme hadn't updated on the zola website. After some investigation I discovered this repo.  Instead of making the PR here to update all submodules, I thought it would make sense to create a github action to do the same thing.

It runs [daily at 5:51 UTC](https://crontab.guru/#51_5_*_*_*). The github docs recommended not scheduling actions on the hour, so in search of a random time during the day, I picked the time of the [first commit](https://github.com/getzola/zola/commit/021b8ea21f224033060895981e5ff00ad80f55c7) to zola. 

The action commits the results to master if there are any changes, and the author of the commit is "actions@github.com", see [example](https://github.com/emilioziniades/themes/commit/a2c7db9f72600593a2b6e9321196172b2552856b) here.

It can also be triggered manually from the github actions UI.