### PR TITLE
Updated version of upload-artifact module in the workflow file

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -23,7 +23,7 @@ jobs:
         run: pip install -r requirements.txt
       - name: Run the generator script
         run: python generate_docs.py site
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: themes-directory
           path: site/*


### PR DESCRIPTION
The version that was used before is not supported anymore and leads to pipeline failures.

I, however, do not know how to test that the changed pipeline works, as the pipeline is only executed on the main branch, as far as I see.