### PR TITLE
Add terminus theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -324,3 +324,6 @@
 [submodule "parchment"]
 	path = parchment
 	url = https://github.com/jsonfry/parchment
+[submodule "terminus"]
+	path = terminus
+	url = https://github.com/ebkalderon/terminus.git


### PR DESCRIPTION
My personal website has been built with Zola since 2019, previously using the [zerm](https://github.com/ejmg/zerm) theme. Due to lack of activity in recent years and still-unfixed bugs, I decided to write my own theme instead. I think it's finally in a good enough state to share, so here's my PR to add it to the theme gallery!

[Terminus](https://github.com/ebkalderon/terminus) is a fork/re-implementation of Radek Kozieł's [Terminal Theme for Hugo](https://github.com/panr/hugo-theme-terminal), but with several key improvements (e.g. better accessibility, high Lighthouse score, social icons in site footer, more built-in shortcodes, and support for GitHub style alerts). A few design elements also descend from [zerm](https://github.com/ejmg/zerm) and [tabi](https://github.com/welpo/tabi) as well.

Thanks in advance for taking a look. :heart: 

<img width="1909" height="1426" alt="Screenshot of the home page of the Terminus demo website" src="https://github.com/user-attachments/assets/a600fc7b-e3ef-4b0f-b758-0d82d8c4719f" />