### PR TITLE
Add broadside theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -403,3 +403,6 @@
 [submodule "still"]
 	path = still
 	url = https://github.com/wjianbo/zola-theme-still.git
+[submodule "broadside"]
+	path = broadside
+	url = https://github.com/nsrosenqvist/broadside


### PR DESCRIPTION
This is a theme I made for a personal website that I haven't made available yet, but I figured that I might as well share the theme with the community.

It's a typography-focused blog theme with a newspaper-inspired look - serif headlines, thin rules, lots of whitespace. Designed for long-form writing. Dark mode via prefers-color-scheme, CSS-based syntax highlighting.

<img width="1500" height="1000" alt="screenshot" src="https://github.com/user-attachments/assets/6ac1bd36-b725-4f93-be46-875c8e99ba3f" />


**Main features:**

- Three-tier index layout (featured post, card grid, text list)
- Drop caps on articles
- Category taxonomy support
- Previous/next post navigation
- OpenGraph, Twitter Card, and Schema.org JSON-LD metadata
- Responsive single-column on mobile

Uses Playfair Display for headlines, Source Serif 4 for body text, Inter for UI, and JetBrains Mono for code. All colors are CSS custom properties so they're easy to override.