### PR TITLE
Add researchlab theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -406,3 +406,6 @@
 [submodule "broadside"]
 	path = broadside
 	url = https://github.com/nsrosenqvist/broadside
+[submodule "researchlab"]
+	path = researchlab
+	url = https://codeberg.org/plaublin/researchlab.git


### PR DESCRIPTION
### Summary
- Add the researchlab Zola theme as a git submodule.
- Point the submodule to the latest published theme commit.