### PR TITLE
Add avel theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -409,3 +409,6 @@
 [submodule "harmless"]
 	path = harmless
 	url = https://github.com/e4779/zola-harmless.git
+[submodule "avel"]
+	path = avel
+	url = https://github.com/kako-jun/avel.git


### PR DESCRIPTION
Adds **avel**, an ultra-lightweight no-JS blog theme inspired by Hiroshi Abe’s famously lightweight official
  homepage.

  Theme repository: https://github.com/kako-jun/avel
  Demo: https://avel.llll-ll.com

  Validation:
  - Added as a git submodule
  - `theme.toml` uses the generator-compatible `[author]` metadata
  - `screenshot.png` is present at 1280x720
  - `uv run --with toml python3 generate_docs.py /tmp/zola-themes-generated` successfully processed `avel`