### PR TITLE
Add zola-suckless-theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -412,3 +412,6 @@
 [submodule "press-start"]
 	path = press-start
 	url = https://github.com/brandonhon/press-start.git
+[submodule "zola-suckless-theme"]
+	path = zola-suckless-theme
+	url = https://github.com/enzv/zola-suckless-theme.git


### PR DESCRIPTION
This PR adds zola-suckless-theme to the Zola themes repository as a git submodule.

https://github.com/enzv/zola-suckless-theme

The theme follows a minimal, suckless-inspired style and is ready to be listed in the community themes collection