### PR TITLE
Add DevLab theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -415,3 +415,6 @@
 [submodule "zola-suckless-theme"]
 	path = zola-suckless-theme
 	url = https://github.com/enzv/zola-suckless-theme.git
+[submodule "devlab-theme"]
+	path = devlab-theme
+	url = https://codeberg.org/ripetitor/devlab-theme.git


### PR DESCRIPTION
Main theme -> https://codeberg.org/RiPetitor/devlab-theme
Demo -> https://ripetitor.codeberg.page/devlab-theme/

I'm trying to spend more time writing my theme for Zola, but I see that Tera 2 is coming out soon in the Zola engine and will most likely need to be redesigned. Therefore, the development of the theme is frozen until the release of the new Zola engine.