### PR TITLE
Add zola-quiet theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -415,3 +415,6 @@
 [submodule "zola-suckless-theme"]
 	path = zola-suckless-theme
 	url = https://github.com/enzv/zola-suckless-theme.git
+[submodule "zola-quiet"]
+	path = zola-quiet
+	url = https://github.com/johnnybravo-xyz/zola-quiet.git


### PR DESCRIPTION
Adds `zola-quiet` as a submodule.

- Two-skin theme: Minima-flavoured typographic default and a TUI/ncurses skin with an ASCII-drawn article frame. Both ship matched light + dark modes and a runtime toggle in the top-right.
- Posts with headings render a docs-style on-page TOC pinned under the sidebar on the TUI skin, with scroll-spy for the active section.
- Shareable heading anchor prefix (`>`), addendum block convention, iframe theme-sync protocol for embedded visualisers.
- Ships `theme.toml`, `LICENSE` (MIT), and `screenshot.png`. `minimum_version = 0.19.0`.

Repository: https://github.com/johnnybravo-xyz/zola-quiet
Live example: https://johnnybravo.xyz