### PR TITLE
Add zola-astroplate theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -424,3 +424,7 @@
 [submodule "volks-typo"]
 	path = volks-typo
 	url = https://gitlab.com/tisgoud/zola-volks-typo-theme
+[submodule "zola-astroplate"]
+	path = zola-astroplate
+	url = https://github.com/worrydont/zola-astroplate.git
+	branch = main


### PR DESCRIPTION
Adds **zola-astroplate** to the gallery.

- Repo: https://github.com/worrydont/zola-astroplate
- Astroplate ported to Zola (Tailwind v4, i18n, search)
- License: MIT · min Zola version: 0.19.0
- Includes `theme.toml`, `screenshot.png`, and `README.md`