### PR TITLE
Add the tapestry theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -424,3 +424,6 @@
 [submodule "volks-typo"]
 	path = volks-typo
 	url = https://gitlab.com/tisgoud/zola-volks-typo-theme
+[submodule "tapestry"]
+	path = tapestry
+	url = https://github.com/anirbanbasu/tapestry.git


### PR DESCRIPTION
Tapestry is a Zola theme for researcher profile websites. The tapestry theme is inspired by and derived from the [terminus](https://github.com/ebkalderon/terminus) theme, specifically its `aa8d8b67f9ab69ae48e1405f96e152d41f03e0ed` commit. It supports both dark and light modes. It has five different presentation styles, each with five different variants giving the user plenty of preset accessibility-checked options. See [screenshot](https://github.com/anirbanbasu/tapestry/blob/master/screenshot.png) of the _creative_ style and the _editorial-zine_ variant.

Try the demo at the following links.

- [Netlify](https://ghp-tapestry.netlify.app/)
- [GitHub pages](https://ghp-tapestry.anirbanbasu.com/)

Note: The theme is being developed and maintained in a repository separate from the one where the theme can be and should be installed from. See [the development repository](https://github.com/anirbanbasu/theme-tapestry-dev).

This theme is currently in beta. However, the following things have been completed.

- [x] Exhaustive automated WCAG AA checks for every pull request to add or update features in the theme.
- [x] Lighthouse [performance test reports available](https://github.com/anirbanbasu/theme-tapestry-dev/tree/master/lighthouse-reports), and are planned to be regularly updated.
- [x] Exhaustive documentation, including documentation akin to the terminus theme.

License: MIT.