### PR TITLE
Add Zulqer theme

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -434,3 +434,6 @@
 [submodule "simplepod"]
 	path = simplepod
 	url = https://github.com/cbrake/simplepod
+[submodule "zulqer"]
+	path = zulqer
+	url = https://github.com/menzil/zulqer.git


### PR DESCRIPTION
Adds Zulqer as a community theme submodule. Zulqer is a dark editorial theme for Zola 0.23 and later.

- Repository: https://github.com/menzil/zulqer
- Demo: https://orhan.cn/
- Release: https://github.com/menzil/zulqer/releases/tag/v0.1.0

The submodule is pinned to the v0.1.0 commit.